### PR TITLE
AWS Lambda - causes problems when execution context reused

### DIFF
--- a/lib/Window.js
+++ b/lib/Window.js
@@ -26,8 +26,8 @@ function Window(context) {
 }
 
 Object.defineProperty(console, 'log', {
-    configurable: false,
-    writable: false
+    configurable: true,
+    writable: true
 })
 
 Window.prototype = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "libxmljs-dom",
-    "version": "0.0.8",
+    "version": "0.0.11",
     "description": "DOM wrapper for libxmljs",
     "keywords": [
         "dom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "libxmljs-dom",
-    "version": "0.0.11",
+    "version": "0.0.14",
     "description": "DOM wrapper for libxmljs",
     "keywords": [
         "dom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "libxmljs-dom",
-    "version": "0.0.11",
+    "version": "0.0.13",
     "description": "DOM wrapper for libxmljs",
     "keywords": [
         "dom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "libxmljs-dom",
-    "version": "0.0.13",
+    "version": "0.0.11",
     "description": "DOM wrapper for libxmljs",
     "keywords": [
         "dom",

--- a/test/Window.js
+++ b/test/Window.js
@@ -1,4 +1,5 @@
 var libxmljs = require('../index');
+var consoleLog = console.log;
 
 module.exports.new = function(assert) {
     var window = new libxmljs.Window();
@@ -7,5 +8,31 @@ module.exports.new = function(assert) {
     assert.ok(window.parent === window);
     assert.ok(window.top === window);
     assert.ok(window.window === window);
+
+    // ensure that console.log has been defined
+    assert.ok(console.log !== undefined)
+
     assert.done();
+}
+
+module.exports.lambdaEnvironment = function(assert) {
+	// simulate us being in a AWS lambda environment
+	process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejsX.Y'
+	
+	// console.log is overwritten on each lambda run, preventing
+	// ability to overwrite causes aws lambda to fail. ensure
+	// that this does not fail in lambda environment.
+	assert.doesNotThrow(function() {
+		'use strict'
+		var window = new libxmljs.Window();
+
+		console.log = 1234;
+	},Error)
+	
+	assert.done();
+}
+
+module.exports.tearDown = function(callback) {
+	console.log = consoleLog;
+	callback();
 }


### PR DESCRIPTION
This library causes problems in AWS Lambda. Specifically setting `console.log` to an immutable property causes issues. This is due to the potential reuse of execution context AND the fact that lambda attempts to overwrite `console.log` on each invocation. These base details are documented here:

- https://docs.aws.amazon.com/lambda/latest/dg/running-lambda-code.html
- https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html

This means that using this library in AWS Lambda will cause the following error in the event that execution context is reused:

```
TypeError: Cannot assign to read only property 'log' of #<Console>
```

Here is an example of this in action:

```
// example lambda function that sets console.log to immutable
exports.handler = function(event, context) {
    console.log('STARTING...');
    
    Object.defineProperty(console, 'log', {
        configurable: false,
        writable: false
    })
    
    console.log('ENDING...');
    context.done(null, 'Hello from Lambda');
};
```

The first time we run this we get the expected normal behavior:
```
Response:
"Hello from Lambda"

Request ID:
"d1076581-1cd3-11e8-9fcd-0f3cf6ad5e3c"

Function Logs:
START RequestId: d1076581-1cd3-11e8-9fcd-0f3cf6ad5e3c Version: $LATEST
2018-02-28T22:07:52.062Z	d1076581-1cd3-11e8-9fcd-0f3cf6ad5e3c	STARTING...
2018-02-28T22:07:52.063Z	d1076581-1cd3-11e8-9fcd-0f3cf6ad5e3c	ENDING...
END RequestId: d1076581-1cd3-11e8-9fcd-0f3cf6ad5e3c
REPORT RequestId: d1076581-1cd3-11e8-9fcd-0f3cf6ad5e3c	Duration: 3.14 ms	Billed Duration: 100 ms 	Memory Size: 128 MB	Max Memory Used: 20 MB
```

The second time this gets run, we see an error. This is because lambda is attempting to change `console.log`, except our current execution context has `console.log` set to immutable:
```
Response:
{
  "errorMessage": "RequestId: e3f96673-1cd3-11e8-aa7b-3f9cc44a4478 Process exited before completing request"
}

Request ID:
"e3f96673-1cd3-11e8-aa7b-3f9cc44a4478"

Function Logs:
START RequestId: e3f96673-1cd3-11e8-aa7b-3f9cc44a4478 Version: $LATEST
2018-02-28T22:08:22.378Z	e3f96673-1cd3-11e8-aa7b-3f9cc44a4478	TypeError: Cannot assign to read only property 'log' of #<Console>
END RequestId: e3f96673-1cd3-11e8-aa7b-3f9cc44a4478
REPORT RequestId: e3f96673-1cd3-11e8-aa7b-3f9cc44a4478	Duration: 215.57 ms	Billed Duration: 300 ms 	Memory Size: 128 MB	Max Memory Used: 20 MB	
RequestId: e3f96673-1cd3-11e8-aa7b-3f9cc44a4478 Process exited before completing request
```

According to https://aws.amazon.com/blogs/compute/container-reuse-in-lambda/:

> There’s also effectively a fourth way to exit – by crashing or calling process.exit(). For example, if you include a binary library with a bug and it segfaults, you’ll effectively terminate execution of that container.

This means that the previous run not only was unsuccessful, but also prevented us from reusing the container execution context in subsequent runs (hence, higher startup cost since the execution context has to be recreated all over again). We see that on the next run it is successful (since a new execution context was created):

```
Response:
"Hello from Lambda"

Request ID:
"e8213e4d-1cd3-11e8-979d-6556e7e56391"

Function Logs:
START RequestId: e8213e4d-1cd3-11e8-979d-6556e7e56391 Version: $LATEST
2018-02-28T22:08:29.315Z	e8213e4d-1cd3-11e8-979d-6556e7e56391	STARTING...
2018-02-28T22:08:29.316Z	e8213e4d-1cd3-11e8-979d-6556e7e56391	ENDING...
END RequestId: e8213e4d-1cd3-11e8-979d-6556e7e56391
REPORT RequestId: e8213e4d-1cd3-11e8-979d-6556e7e56391	Duration: 3.09 ms	Billed Duration: 100 ms 	Memory Size: 128 MB	Max Memory Used: 18 MB
```

This behavior will continue indefinitely (`success`, `failure`, `success`, `failure`,...).

This pull request fixes the problem by making `console.log` mutable. We see that by making this simple change to the lambda function:

```
// example lambda function that sets console.log to immutable
exports.handler = function(event, context) {
    console.log('STARTING...');
    
    Object.defineProperty(console, 'log', {
        configurable: true,
        writable: true
    })
    
    console.log('ENDING...');
    context.done(null, 'Hello from Lambda');
};
```

Then all the runs are successful--first run (**SUCCESS**):
```
Response:
"Hello from Lambda"

Request ID:
"00f591ee-1cd7-11e8-a922-31f892d79dc0"

Function Logs:
START RequestId: 00f591ee-1cd7-11e8-a922-31f892d79dc0 Version: $LATEST
2018-02-28T22:30:39.729Z	00f591ee-1cd7-11e8-a922-31f892d79dc0	STARTING...
2018-02-28T22:30:39.731Z	00f591ee-1cd7-11e8-a922-31f892d79dc0	ENDING...
END RequestId: 00f591ee-1cd7-11e8-a922-31f892d79dc0
REPORT RequestId: 00f591ee-1cd7-11e8-a922-31f892d79dc0	Duration: 84.45 ms	Billed Duration: 100 ms 	Memory Size: 128 MB	Max Memory Used: 19 MB	
```

Second run (**SUCCESS**):
```
Response:
"Hello from Lambda"

Request ID:
"0d43499f-1cd7-11e8-8839-e3d8bda55929"

Function Logs:
START RequestId: 0d43499f-1cd7-11e8-8839-e3d8bda55929 Version: $LATEST
2018-02-28T22:31:00.106Z	0d43499f-1cd7-11e8-8839-e3d8bda55929	STARTING...
2018-02-28T22:31:00.106Z	0d43499f-1cd7-11e8-8839-e3d8bda55929	ENDING...
END RequestId: 0d43499f-1cd7-11e8-8839-e3d8bda55929
REPORT RequestId: 0d43499f-1cd7-11e8-8839-e3d8bda55929	Duration: 1.03 ms	Billed Duration: 100 ms 	Memory Size: 128 MB	Max Memory Used: 19 MB
```

This PR ensures that `console.log` remains mutable. Thanks to @IoannMelnychuk for identifying this issue!