### PR TITLE
Updated libxmljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "needle": ">=0.9.2",
-        "libxmljs": "0.19.0",
+        "libxmljs": "0.19.5",
         "css2xpath": "0.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
This solves the security problems of the old versions of hoek by updating the node-pre-gyp dependency.

├─┬ libxmljs@0.19.0
│ ├── bindings@1.3.0
│ ├── nan@2.10.0
│ └─┬ node-pre-gyp@0.6.39
│   ├── detect-libc@1.0.3
│   ├─┬ hawk@3.1.3
│   │ ├─┬ boom@2.10.1
│   │ │ └── hoek@2.16.3