### PR TITLE
Allow libxmljs minor version upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "needle": ">=0.9.2",
-        "libxmljs": "0.19.0",
+        "libxmljs": "^0.19.0",
         "css2xpath": "0.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
It is impossible to install libxmljs of exactly 0.19.0 on certain configurations. For example in ArchLinux with latest node-v67(11.1.0) build of libxmljs@0.19.0 fails, while libxmljs@0.19.5 works.

To avoid such issues, allow using any minor version of libxmljs higher than 0.19.0