### PR TITLE
fix invalid needle defaults error

### DIFF
--- a/lib/HttpRequest.js
+++ b/lib/HttpRequest.js
@@ -4,12 +4,10 @@ var needle  = require('needle');
 
 needle.defaults({
     follow: 3,
-    compressed: true,
     parse_response: false,
     decode_response: true,
     follow_set_cookies: true,
-    follow_set_referer: true,
-    rejectUnauthorized: false
+    follow_set_referer: true
 })
 
 function HttpRequest(window, url, callback) {
@@ -30,9 +28,11 @@ function HttpRequest(window, url, callback) {
         //headers:    url.headers,
         headers: {
             referer:    url.referer||window.location.href,
+            compressed: true,
         },
         cookies:    window.document.cookies,
-        accept:     url.accept
+        accept:     url.accept,
+        rejectUnauthorized: false
     }
 
     window.__stackPush();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "libxmljs-dom",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "DOM wrapper for libxmljs",
     "keywords": [
         "dom",


### PR DESCRIPTION
The `compressed` and `rejectUnauthorized` options are not allowed in `needle.defaults`. They're respectively `HttpHeader` (https://github.com/tomas/needle#http-header-options) and `HttpRequest` (https://github.com/tomas/needle#nodejs-tls-options) options.

Since `v2.3.1`, needle throws an error because of these 2 options (https://github.com/tomas/needle/blob/master/lib/needle.js#L775), I guess they were just noop before that. Unit tests are failing with latest version of `needle` without this patch.