### PR TITLE
needle@2.5.0 - Invalid property for defaults:rejectUnauthorized

### DIFF
--- a/lib/HttpRequest.js
+++ b/lib/HttpRequest.js
@@ -8,8 +8,7 @@ needle.defaults({
     parse_response: false,
     decode_response: true,
     follow_set_cookies: true,
-    follow_set_referer: true,
-    rejectUnauthorized: false
+    follow_set_referer: true
 })
 
 function HttpRequest(window, url, callback) {
@@ -32,7 +31,8 @@ function HttpRequest(window, url, callback) {
             referer:    url.referer||window.location.href,
         },
         cookies:    window.document.cookies,
-        accept:     url.accept
+        accept:     url.accept,
+        rejectUnauthorized: false
     }
 
     window.__stackPush();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "libxmljs-dom",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "DOM wrapper for libxmljs",
     "keywords": [
         "dom",


### PR DESCRIPTION
When running with needle 2.5.0 I was seeing this error:

```
Error: Invalid property for defaults:rejectUnauthorized' when running tests.
```

This update moved `rejectUnauthorized` to the expected location in needle.