### PR TITLE
fixed bug

### DIFF
--- a/lib/HttpRequest.js
+++ b/lib/HttpRequest.js
@@ -8,8 +8,7 @@ needle.defaults({
     parse_response: false,
     decode_response: true,
     follow_set_cookies: true,
-    follow_set_referer: true,
-    rejectUnauthorized: false
+    follow_set_referer: true
 })
 
 function HttpRequest(window, url, callback) {


### PR DESCRIPTION
Fixing a bug with a key transfer that cannot be set at the endpoint.
The "rejectUnauthorized" key was passed, which is not in the object of possible values in the "defaults" lib "needle" object